### PR TITLE
Remove unnecessary build/run requirements in conda recipe

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,7 +14,6 @@ build:
 requirements:
   build:
     - python
-    - pytest
     - setuptools
     - numpy
     - openmm
@@ -23,8 +22,6 @@ requirements:
     - parmed
   run:
     - python
-    - pytest
-    - setuptools
     - numpy
     - openmm
     - pyparsing


### PR DESCRIPTION
- Remove `pytest` from build + run requirements.
- Remove `setuptools` from run requirements